### PR TITLE
update readmes, clean up test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 # workbench-tos
 APIs - currently implemented as a Cloud Function - for users' responses to Terms of Service.
 
+# Developer setup
+This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 6.14, or whatever minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/nodejs-6-runtime. If you already have a different version of Node on your system, you might be interested in *[nvm](https://github.com/creationix/nvm)*.
+
+
+To install third-party libraries, first `cd function`, then `npm install`. You will need to `npm install` any time [package.json](function/package.json) or [package-lock.json](function/package-lock.json) changes. Conversely, if those files have not changed since your last install, you should not have to run `npm install`.
+
 # Testing
-1. Install the [Cloud Functions Node.js Emulator](https://cloud.google.com/functions/docs/emulator), including its dependencies such as Node.js >= 6.11.1.
-2. `cd function` - make sure you're in the right directory. The root of this repostory is NOT the right directory!
-3. `npm install` to get all the third-party dependencies
-4. start the emulator with `functions-emulator start`
-5. `npm test`
-
-## Optimizing test runs
-By default, `npm test` will redeploy the function code to the emulator every time it runs. This is slow. If you are not changing function code between test runs - for instance, you are writing new tests - you may want to disable auto-deploy. Do this by commenting out the single line of code in [updateFunction.sh](function/test/updateFunction.sh).
-
-
+1. `cd function` - make sure you're in the right directory. The root of this repostory is NOT the right directory!
+2. `npm install` - get all the third-party dependencies, if you have not done so already. `npm i` is the shorthand.
+3. `npm test`
 
 # Linting
 1. `cd function` - make sure you're in the right directory. The root of this repostory is NOT the right directory!
-2. `npm install` to get all the third-party dependencies
-3. `npm run lint`
+2. `npm install` - get all the third-party dependencies, if you have not done so already. `npm i` is the shorthand.
+3. `npm run lint` - note you need the extra `run` command.
 
 As of this writing, `npm run lint` has a lot of errors! Fixing these is an outstanding TODO.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 APIs - currently implemented as a Cloud Function - for users' responses to Terms of Service.
 
 # Developer setup
-This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 6.14, or whatever minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/nodejs-6-runtime. If you already have a different version of Node on your system, you might be interested in *[nvm](https://github.com/creationix/nvm)*.
+This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 6.14, or whatever minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/nodejs-6-runtime.
 
+If you already have a different version of Node on your system, you might be interested in *[nvm](https://github.com/creationix/nvm)*.
+
+If you have a hard time finding Node 6.14 to install, you really might be interested in *[nvm](https://github.com/creationix/nvm)*. First, install *nvm* according to their instructions. Then, use *nvm* to install and use the appropriate version of Node, e.g. `nvm install 6.14.4`. *nvm* will automatically use the version of Node you just installed, but for good measure you can `nvm ls` to see installed versions, then `nvm use 6.14.4` to use that version if you aren't already using it.
 
 To install third-party libraries, first `cd function`, then `npm install`. You will need to `npm install` any time [package.json](function/package.json) or [package-lock.json](function/package-lock.json) changes. Conversely, if those files have not changed since your last install, you should not have to run `npm install`.
 

--- a/datastore/README.md
+++ b/datastore/README.md
@@ -1,8 +1,12 @@
 
 # Indexes
+Start here: https://cloud.google.com/datastore/docs/concepts/indexes for an introduction to *indexes* in Datastore.
+
 The [index.yaml](index.yaml) in this directory contains the indexes necessary to power the TOS-related queries. Since Datastore is shared for an entire Google project, please note that other applications may need other indexes; be wary of running `cleanup-indexes`.
 
 # Data Structure
+Start here: https://cloud.google.com/datastore/docs/concepts/entities#kinds_and_identifiers for an introduction to *kinds* in Datastore.
+
 The TOS function expects three Datastore kinds: `Application`, `TermsOfService`, and `TOSResponse`. These represent an application (ex. FireCloud), a Terms of Service for that application and a user's response to that Terms of Service, respectively. All three kinds reside in a namespace named `app`.
 
 All `TOSResponse` entities must have a `TermsOfService` entity as their ancestor, and all `TermsOfService` entities must have an `Application` entity as their ancestor.
@@ -24,8 +28,8 @@ All `TermsOfService` entities must have an `Application` entity as their ancesto
 ## TOSResponse
 The `TOSResponse` kind expects the following properties:
 
-* `userid`: String, ex. '123456'
-* `email`: String, ex. help@example.com
+* `userid`: String, the unique id for the user; ex. '123456'
+* `email`: String, the email address for the user; ex. help@example.com
 * `accepted`: Boolean, whether or not the user accepted the terms of service
 * `timestamp`: Date/time, should be the datetime of insertion
 

--- a/function/package.json
+++ b/function/package.json
@@ -12,8 +12,7 @@
   "scripts": {
     "lint": "eslint --ignore-path ../.gitignore .",
     "test": "nyc ava --timeout=30s --verbose test/*test.js",
-    "test-report": "mkdir -p test/reports/unit && nyc ava --tap --timeout=30s --verbose test/*test.js > test/reports/unit/ava.tap",
-    "integration-test": "export FUNCTIONS_CMD='functions-emulator' && sh test/updateFunction.sh && export BASE_URL=\"http://localhost:8010/$GCP_PROJECT/$GCF_REGION\" && ava -T 20s --verbose -c 1 test/index.test.js test/*unit*test.js test/*integration*test.js"
+    "test-report": "mkdir -p test/reports/unit && nyc ava --tap --timeout=30s --verbose test/*test.js > test/reports/unit/ava.tap"
   },
   "devDependencies": {
     "ava": "1.0.0-beta.7",

--- a/function/test/updateFunction.sh
+++ b/function/test/updateFunction.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-# Shell script to emulate/deploy the cloud function
-# ${FUNCTIONS_CMD} deploy tos --trigger-http


### PR DESCRIPTION
remove the unused `updateFunction.sh` script and `integration-test` npm command.

update readmes to be correct regarding test commands and more verbose about developer setup, dependency installation, and data structures.