### PR TITLE
deploy script [risk: low]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+deploy_account.json
 function/node_modules
 function/test/reports
 function/.nyc_output

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+VAULT_TOKEN=$1
+GIT_BRANCH=$2
+
+if [ "$GIT_BRANCH" == "develop" ]; then
+    ENVIRONMENT="dev"
+elif [ "$GIT_BRANCH" == "alpha" ]; then
+    ENVIRONMENT="alpha"
+elif [ "$GIT_BRANCH" == "perf" ]; then
+	ENVIRONMENT="perf"
+elif [ "$GIT_BRANCH" == "staging" ]; then
+    ENVIRONMENT="staging"
+elif [ "$GIT_BRANCH" == "master" ]; then
+    ENVIRONMENT="prod"
+else
+    echo "Git branch '$GIT_BRANCH' is not configured to automatically deploy to a target environment"
+    exit 1
+fi
+
+PROJECT_NAME="broad-dsde-${ENVIRONMENT}"
+
+SERVICE_ACCT_KEY_FILE="deploy_account.json"
+# Get the tier specific credentials for the service account out of Vault
+# Put key into SERVICE_ACCT_KEY_FILE
+#
+# NB: we read the secret from Martha's path. Both Martha and workbench-tos are Cloud Functions and share the same permissions as far
+# as who can deploy - so we just reuse Martha's creds here.
+#
+# TODO: move both Martha and workbench-tos deploys to read from a common path instead of the Martha path to avoid confusion
+docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/martha/${ENVIRONMENT}/deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
+
+CODEBASE_PATH=/workbench-tos
+# Process all Consul .ctmpl files
+# Vault token is required by the docker image regardless of whether you having any data in Vault or not
+docker run --rm -v $PWD:${CODEBASE_PATH} \
+  -e INPUT_PATH=${CODEBASE_PATH}/function \
+  -e OUT_PATH=${CODEBASE_PATH}/function \
+  -e ENVIRONMENT=${ENVIRONMENT} \
+  -e VAULT_TOKEN=${VAULT_TOKEN} \
+  broadinstitute/dsde-toolbox render-templates.sh
+
+# Use google/cloud-sdk image to deploy the cloud function
+# TODO: is there a smaller version of this image we can use?
+docker run --rm -v $PWD:${CODEBASE_PATH} \
+    -e BASE_URL="https://us-central1-broad-dsde-${ENVIRONMENT}.cloudfunctions.net" \
+    google/cloud-sdk:latest /bin/bash -c \
+    "gcloud config set project ${PROJECT_NAME} &&
+     gcloud auth activate-service-account --key-file ${CODEBASE_PATH}/${SERVICE_ACCT_KEY_FILE} &&
+     cd ${CODEBASE_PATH} &&
+     gcloud beta functions deploy tos --source=./function --trigger-http --runtime nodejs6"

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,9 +9,8 @@ if [ "$GIT_BRANCH" == "develop" ]; then
     ENVIRONMENT="dev"
 elif [ "$GIT_BRANCH" == "alpha" ]; then
     ENVIRONMENT="alpha"
-# TODO: we don't support auto-deploy to perf yet.
-# elif [ "$GIT_BRANCH" == "perf" ]; then
-#	ENVIRONMENT="perf"
+elif [ "$GIT_BRANCH" == "perf" ]; then
+	ENVIRONMENT="perf"
 elif [ "$GIT_BRANCH" == "staging" ]; then
     ENVIRONMENT="staging"
 elif [ "$GIT_BRANCH" == "master" ]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,8 +9,9 @@ if [ "$GIT_BRANCH" == "develop" ]; then
     ENVIRONMENT="dev"
 elif [ "$GIT_BRANCH" == "alpha" ]; then
     ENVIRONMENT="alpha"
-elif [ "$GIT_BRANCH" == "perf" ]; then
-	ENVIRONMENT="perf"
+# TODO: we don't support auto-deploy to perf yet.
+# elif [ "$GIT_BRANCH" == "perf" ]; then
+#	ENVIRONMENT="perf"
 elif [ "$GIT_BRANCH" == "staging" ]; then
     ENVIRONMENT="staging"
 elif [ "$GIT_BRANCH" == "master" ]; then
@@ -25,12 +26,7 @@ PROJECT_NAME="broad-dsde-${ENVIRONMENT}"
 SERVICE_ACCT_KEY_FILE="deploy_account.json"
 # Get the tier specific credentials for the service account out of Vault
 # Put key into SERVICE_ACCT_KEY_FILE
-#
-# NB: we read the secret from Martha's path. Both Martha and workbench-tos are Cloud Functions and share the same permissions as far
-# as who can deploy - so we just reuse Martha's creds here.
-#
-# TODO: move both Martha and workbench-tos deploys to read from a common path instead of the Martha path to avoid confusion
-docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/martha/${ENVIRONMENT}/deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
+docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/${ENVIRONMENT}/common/cloud-function-deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
 
 CODEBASE_PATH=/workbench-tos
 # Process all Consul .ctmpl files

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,13 +24,13 @@ fi
 PROJECT_NAME="broad-dsde-${ENVIRONMENT}"
 
 SERVICE_ACCT_KEY_FILE="deploy_account.json"
-# Get the tier specific credentials for the service account out of Vault
+# Get the environment-specific credentials for the service account out of Vault
 # Put key into SERVICE_ACCT_KEY_FILE
 docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/${ENVIRONMENT}/common/cloud-function-deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
 
 CODEBASE_PATH=/workbench-tos
 # Process all Consul .ctmpl files
-# Vault token is required by the docker image regardless of whether you having any data in Vault or not
+# Vault token is required by the docker image regardless of whether you have any data in Vault or not
 docker run --rm -v $PWD:${CODEBASE_PATH} \
   -e INPUT_PATH=${CODEBASE_PATH}/function \
   -e OUT_PATH=${CODEBASE_PATH}/function \

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,7 +26,7 @@ PROJECT_NAME="broad-dsde-${ENVIRONMENT}"
 SERVICE_ACCT_KEY_FILE="deploy_account.json"
 # Get the environment-specific credentials for the service account out of Vault
 # Put key into SERVICE_ACCT_KEY_FILE
-docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/${ENVIRONMENT}/common/cloud-function-deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
+docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/firecloud/${ENVIRONMENT}/common/cloud-function-deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
 
 CODEBASE_PATH=/workbench-tos
 # Process all Consul .ctmpl files


### PR DESCRIPTION
for DataBiosphere/firecloud-app#181.

This adds a `deploy.sh`, modeled heavily after [Martha's](https://github.com/broadinstitute/martha/blob/dev/deploy.sh), that will be used by a Jenkins-based commit trigger to automatically deploy the workbench-tos Cloud Function upon commit to relevant branches (develop, alpha, staging, master).

I have run this manually against develop, alpha, and staging, and saw it work. I am intentionally not deploying to prod/master yet.

What I've done already:
* populate the Vault secrets
* configure Datastore in all envs except prod
* manually test the cloud function in all envs except prod

Still to-do, which I will handle sometime after this PR:
* update Martha's deploy.sh to read from `secret/dsde/${ENVIRONMENT}/common/cloud-function-deploy-account.json` instead of its Martha-specific location (right now the same creds are copied in both places)
* make the Jenkins trigger job, again based heavily off Martha's work