### PR TITLE
validate OAuth token audience/email/expires/etc [risk: medium]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 deploy_account.json
+function/config.js
 function/node_modules
 function/test/reports
 function/.nyc_output

--- a/function/.gcloudignore
+++ b/function/.gcloudignore
@@ -15,5 +15,6 @@
 
 .eslintrc.json
 .nyc_output
+config.js.ctmpl
 node_modules
 test

--- a/function/authorization.js
+++ b/function/authorization.js
@@ -5,7 +5,14 @@ const _ = require('lodash');
 
 const { rejection, ResponseError } = require('./responseError');
 
-// fail-safe handling of potentially-missing require
+// fail-safe handling of potentially-missing require. In live deploys, this require
+// will exist because our deploy process will render it based on config.js.ctmpl.
+// if you have simply checked out the codebase and are running unit tests - without
+// rendering .ctmpls - the require will not exist. We want to allow this.
+//
+// Unit tests override the audiencePrefixes and emailSuffixes values.
+// In a live deploy, if the config is missing, we default to [], which equates to an
+// empty whitelist.
 let audiencePrefixes = [];
 let emailSuffixes = [];
 try {
@@ -30,7 +37,7 @@ class GoogleOAuthAuthorizer {
     constructor(configObj) {
         const config = configObj || {};
         this.audiencePrefixes = config.audiencePrefixes || audiencePrefixes;
-        this.emailSuffixes = config.emailSuffixes || audiencePrefixes;
+        this.emailSuffixes = config.emailSuffixes || emailSuffixes;
     }
 
     callTokenInfoApi(token) {

--- a/function/authorization.js
+++ b/function/authorization.js
@@ -97,7 +97,7 @@ class GoogleOAuthAuthorizer {
         }
         // validate audience/email
         if (!this.validateAudienceOrEmail(userinfo.audience.toString(), userinfo.email.toString())) {
-            throw new ResponseError(`OAuth token has unacceptable audience (${userinfo.audience}) or email (${userinfo.email})`, 401);
+            throw new ResponseError(`OAuth token must have an acceptable audience (${userinfo.audience}) or email (${userinfo.email})`, 401);
         };
     }
 

--- a/function/authorization.js
+++ b/function/authorization.js
@@ -77,27 +77,27 @@ class GoogleOAuthAuthorizer {
         // validate all fields exist
         userInfoKeys.forEach( (key) => {
             if (!userinfo.hasOwnProperty(key)) {
-                throw new ResponseError(`OAuth token does not include ${key}`, 403);
+                throw new ResponseError(`OAuth token does not include ${key}`, 401);
             }
         })
         // validate verified_email is Boolean and true
         const verified = userinfo.verified_email;
         if (!_.isBoolean(verified)) {
-            throw new ResponseError('OAuth token verified_email must be a Boolean.', 403);
+            throw new ResponseError('OAuth token verified_email must be a Boolean.', 401);
         } else if (!verified) {
-            throw new ResponseError('OAuth token verified_email must be true.', 403);
+            throw new ResponseError('OAuth token verified_email must be true.', 401);
         }
 
         // validate expires_in is numeric and > 0
         const expires = _.toNumber(userinfo.expires_in);
         if (isNaN(expires)) {
-            throw new ResponseError('OAuth token expires_in must be a number.', 403);
+            throw new ResponseError('OAuth token expires_in must be a number.', 401);
         } else if (expires <= 0) {
-            throw new ResponseError(`OAuth token has expired (expires_in: ${expires})`, 403);
+            throw new ResponseError(`OAuth token has expired (expires_in: ${expires})`, 401);
         }
         // validate audience/email
         if (!this.validateAudienceOrEmail(userinfo.audience.toString(), userinfo.email.toString())) {
-            throw new ResponseError(`OAuth token has unacceptable audience (${userinfo.audience}) or email (${userinfo.email})`, 403);
+            throw new ResponseError(`OAuth token has unacceptable audience (${userinfo.audience}) or email (${userinfo.email})`, 401);
         };
     }
 

--- a/function/authorization.js
+++ b/function/authorization.js
@@ -1,21 +1,37 @@
 // Create persistent/pipelined http client for outbound requests
 const requestPromise = require('request-promise-native');
 const persistentRequest = requestPromise.defaults({forever: true});
+const _ = require('lodash');
 
-const { rejection } = require('./responseError');
+const { rejection, ResponseError } = require('./responseError');
+
+// fail-safe handling of potentially-missing require
+let audiencePrefixes = [];
+let emailSuffixes = [];
+try {
+    const oauthConfig = require('./config');
+    audiencePrefixes = oauthConfig.audiencePrefixes;
+    emailSuffixes = oauthConfig.emailSuffixes;
+} catch (err) {
+    console.warn('could not load OAuth config require. You can ignore this warning if you are running unit tests and have not rendered ctmpls.');
+}
 
 // for replacing the "Bearer " prefix case-insensitively in header values
 const bearerPrefix = /^bearer /i;
 
-// define Authorizers as classes for ease of unit testing - unit tests can mock out parts of these classes.
-class Authorizer {
-    authorize() {
-        throw new Error('subclasses must implement');
-    }
-}
+// the object keys we expect to see in the OAuth token from Google
+const userInfoKeys = ['email', 'verified_email', 'user_id', 'audience', 'expires_in'];
 
-class GoogleOAuthAuthorizer extends Authorizer {
+// define GoogleOAuthAuthorizer as a class for ease of unit testing - unit tests can mock out parts of these classes.
+class GoogleOAuthAuthorizer {
     // TODO: move validation of Authorization request header into this class
+
+    // class constructor accepts config overrides, so unit tests can have some control
+    constructor(configObj) {
+        const config = configObj || {};
+        this.audiencePrefixes = config.audiencePrefixes || audiencePrefixes;
+        this.emailSuffixes = config.emailSuffixes || audiencePrefixes;
+    }
 
     callTokenInfoApi(token) {
         const reqUrl = 'https://www.googleapis.com/oauth2/v2/tokeninfo?access_token=' + token;
@@ -28,6 +44,54 @@ class GoogleOAuthAuthorizer extends Authorizer {
             json: true
         };
         return persistentRequest.post(reqOptions)
+    }
+
+    validateAudienceOrEmail(audience, email) {
+        // following two loops use for..in instead of Array.forEach to allow breaking out early
+        // does the audience value start with one of our whitelisted prefixes?
+        for (const i in this.audiencePrefixes) {
+            const prefix = this.audiencePrefixes[i];
+            if (audience.startsWith(prefix.toString())) {
+                return true;
+            }
+        }
+        // does the email value end with one of our whitelisted suffixes?
+        for (const i in this.emailSuffixes) {
+            const suffix = this.emailSuffixes[i];
+            if (email.endsWith(suffix.toString())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    validateUserInfo(userinfo) {
+        // validate all fields exist
+        userInfoKeys.forEach( (key) => {
+            if (!userinfo.hasOwnProperty(key)) {
+                throw new ResponseError(`OAuth token does not include ${key}`, 403);
+            }
+        })
+        // validate verified_email is Boolean and true
+        const verified = userinfo.verified_email;
+        if (!_.isBoolean(verified)) {
+            throw new ResponseError('OAuth token verified_email must be a Boolean.', 403);
+        } else if (!verified) {
+            throw new ResponseError('OAuth token verified_email must be true.', 403);
+        }
+
+        // validate expires_in is numeric and > 0
+        const expires = _.toNumber(userinfo.expires_in);
+        if (isNaN(expires)) {
+            throw new ResponseError('OAuth token expires_in must be a number.', 403);
+        } else if (expires <= 0) {
+            throw new ResponseError(`OAuth token has expired (expires_in: ${expires})`, 403);
+        }
+        // validate audience/email
+        if (!this.validateAudienceOrEmail(userinfo.audience.toString(), userinfo.email.toString())) {
+            throw new ResponseError(`OAuth token has unacceptable audience (${userinfo.audience}) or email (${userinfo.email})`, 403);
+        };
     }
 
     /**
@@ -44,6 +108,7 @@ class GoogleOAuthAuthorizer extends Authorizer {
             const token = authHeader.replace(bearerPrefix,'');
             return this.callTokenInfoApi(token)
                 .then((userinfo) => {
+                    this.validateUserInfo(userinfo);
                     // TODO: validate audience and/or whitelisted email suffixes
                     return userinfo;
                 })
@@ -57,10 +122,6 @@ class GoogleOAuthAuthorizer extends Authorizer {
             return rejection(401);
         }
     }
-}
-
-const getAuthorizer = function() {
-    return new GoogleOAuthAuthorizer();
 }
 
 module.exports = GoogleOAuthAuthorizer;

--- a/function/authorization.js
+++ b/function/authorization.js
@@ -54,23 +54,30 @@ class GoogleOAuthAuthorizer {
     }
 
     validateAudienceOrEmail(audience, email) {
+        let valid = false;
         // following two loops use for..in instead of Array.forEach to allow breaking out early
+
         // does the audience value start with one of our whitelisted prefixes?
         for (const i in this.audiencePrefixes) {
             const prefix = this.audiencePrefixes[i];
             if (audience.startsWith(prefix.toString())) {
-                return true;
+                valid = true;
+                break;
             }
         }
+        // if we haven't matched an audience,
         // does the email value end with one of our whitelisted suffixes?
-        for (const i in this.emailSuffixes) {
-            const suffix = this.emailSuffixes[i];
-            if (email.endsWith(suffix.toString())) {
-                return true;
+        if (!valid) {
+            for (const i in this.emailSuffixes) {
+                const suffix = this.emailSuffixes[i];
+                if (email.endsWith(suffix.toString())) {
+                    valid = true;
+                    break;
+                }
             }
         }
 
-        return false;
+        return valid;
     }
 
     validateUserInfo(userinfo) {

--- a/function/authorization.js
+++ b/function/authorization.js
@@ -116,7 +116,6 @@ class GoogleOAuthAuthorizer {
             return this.callTokenInfoApi(token)
                 .then((userinfo) => {
                     this.validateUserInfo(userinfo);
-                    // TODO: validate audience and/or whitelisted email suffixes
                     return userinfo;
                 })
                 .catch((err) => {

--- a/function/config.js.ctmpl
+++ b/function/config.js.ctmpl
@@ -1,0 +1,14 @@
+{{with $commonSecrets := vault (printf "secret/dsde/firecloud/common/oauth_client_id")}}
+
+// 1) JS is lenient about trailing commas in these arrays
+// 2) JS **needs** the trailing comma if the array contains a single item, e.g. emailSuffixes.
+//      Without the trailing comma, JS will collapse the array.
+const audiencePrefixes = [{{range $index, $element := $commonSecrets.Data.client_ids}}{{ $element }},{{end}}];
+const emailSuffixes = ['.gserviceaccount.com',];
+
+module.exports = {
+    audiencePrefixes: audiencePrefixes,
+    emailSuffixes: emailSuffixes
+};
+
+{{end}}

--- a/function/test/authorization.unit.test.js
+++ b/function/test/authorization.unit.test.js
@@ -253,7 +253,7 @@ test('authorization: should reject if email key is missing from OAuth userinfo',
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token does not include email');
 });
@@ -268,7 +268,7 @@ test('authorization: should reject if verified_email key is missing from OAuth u
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token does not include verified_email');
 });
@@ -283,7 +283,7 @@ test('authorization: should reject if user_id key is missing from OAuth userinfo
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token does not include user_id');
 });
@@ -298,7 +298,7 @@ test('authorization: should reject if audience key is missing from OAuth userinf
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token does not include audience');
 });
@@ -313,7 +313,7 @@ test('authorization: should reject if expires_in key is missing from OAuth useri
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token does not include expires_in');
 });
@@ -330,7 +330,7 @@ test('authorization: should reject if verified_email is false in OAuth userinfo'
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token verified_email must be true.');
 });
@@ -345,7 +345,7 @@ test('authorization: should reject if verified_email is not a boolean in OAuth u
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token verified_email must be a Boolean.');
 });
@@ -361,7 +361,7 @@ test('authorization: should reject if expires_in is 0 in OAuth userinfo', async 
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token has expired (expires_in: 0)');
 });
@@ -376,7 +376,7 @@ test('authorization: should reject if expires_in is negative in OAuth userinfo',
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token has expired (expires_in: -444)');
 });
@@ -391,7 +391,7 @@ test('authorization: should reject if expires_in is not a number in OAuth userin
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, 'Error authorizing user: OAuth token expires_in must be a number.');
 });
@@ -407,7 +407,7 @@ test('authorization: should reject if neither audience nor email matches whiteli
     }
 
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
-    t.is(error.statusCode, 403);
+    t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
     t.is(error.message, `Error authorizing user: OAuth token has unacceptable audience (${userinfo.audience}) or email (${userinfo.email})`);
 });

--- a/function/test/authorization.unit.test.js
+++ b/function/test/authorization.unit.test.js
@@ -409,7 +409,7 @@ test('authorization: should reject if neither audience nor email matches whiteli
     const error = await t.throwsAsync( tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore) );
     t.is(error.statusCode, 401);
     t.is(error.name, 'ResponseError');
-    t.is(error.message, `Error authorizing user: OAuth token has unacceptable audience (${userinfo.audience}) or email (${userinfo.email})`);
+    t.is(error.message, `Error authorizing user: OAuth token must have an acceptable audience (${userinfo.audience}) or email (${userinfo.email})`);
 });
 
 test('authorization: should validate if audience matches whitelisted prefixes but email does not match whitelisted suffixes', async t => {

--- a/function/test/datastore.unit.test.js
+++ b/function/test/datastore.unit.test.js
@@ -11,6 +11,10 @@ process.env.NODE_ENV = 'test';
 // expects a userinfo object, and echoes that userinfo object back. We do this so different unit tests can specify
 // different users, which is important for the datastore mocks below.
 class SuccessfulMockAuthorizer extends GoogleOAuthAuthorizer {
+    constructor(configObj) {
+        super({audiencePrefixes:[122333444455555,]});
+    }
+
     callTokenInfoApi(userinfoStr) {
         // example userinfo: {user_id: 12321, email: 'fake@fakey.fake'}
         return Promise.resolve(JSON.parse(userinfoStr));
@@ -146,7 +150,7 @@ const getRequest = function(userid, appid = 'FireCloud', tosversion = 20180815.1
         path: '/v1/user/response',
         headers: {
             origin: 'unittest',
-            authorization: `{"user_id": ${userid}, "email": "fake@fakey.fake"}`
+            authorization: `{"user_id": ${userid}, "email": "fake@fakey.fake", "verified_email": true, "audience": 122333444455555, "expires_in": 500}`
         },
         method: 'GET',
         query: {
@@ -162,7 +166,7 @@ const postRequest = function(userid, appid = 'FireCloud', tosversion = 20180815.
         headers: {
             origin: 'unittest',
             'content-type': 'application/json',
-            authorization: `{"user_id": ${userid}, "email": "fake@fakey.fake"}`
+            authorization: `{"user_id": ${userid}, "email": "fake@fakey.fake", "verified_email": true, "audience": 122333444455555, "expires_in": 500}`
         },
         method: 'POST',
         body: {


### PR DESCRIPTION
addresses DataBiosphere/firecloud-app#178

* During Jenkins-triggered deploys, create a config.js based on a whitelist stored in Vault. This config.js holds our tokeninfo whitelist information.
* When validating the tokeninfo response from Google, check:
  * if the token has expired
  * if the email is verified
  * if the audience matches our whitelist (from Vault), OR if the email matches our whitelist

plus, a bunch of unit tests to exercise this code.

see https://github.com/DataBiosphere/bond/blob/15349e412c03e68ef2dd8f19f62decdb4706d68b/authentication.py#L89 for an approved/pre-existing example of this behavior.

@adrazhi tagging you on a `security risk: medium` PR - if this implementation has a bug, it could mean we are not properly validating OAuth token info for this API (note that prior to this PR, we had much less validation)