### PR TITLE
specify a group for reviewers [risk: low]

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -23,6 +23,11 @@ groups:
     users:
       - davidangb
       - jmthibault79
+      - davidbernick
+      - dmohs
+      - hjfbynara
+      - dvoet
+      - kcibul
 
   reviewers:
     conditions:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -15,8 +15,6 @@ group_defaults:
   author_approval:
     ignored: true # Allow developers to approve their own PRs (use-case: emergency hot fix)
 
-# if, in the future, we set up auto-deploy from github branches to live Cloud Function instances,
-# we can control who has the ability to approve here.
 groups:
   pullapprove-admins:
     conditions:
@@ -25,3 +23,15 @@ groups:
     users:
       - davidangb
       - jmthibault79
+
+  reviewers:
+    conditions:
+      branches:
+        - develop
+        - alpha
+        - staging
+        - perf
+        - qa
+        - master
+    teams:
+      - workbench-dev


### PR DESCRIPTION
hoping to fix an oversight that caused pullapprove to not work.