### PR TITLE
treat oauth audiences as strings because JS cant handle numbers that large [risk: low]

### DIFF
--- a/function/authorization.js
+++ b/function/authorization.js
@@ -64,7 +64,7 @@ class GoogleOAuthAuthorizer {
         // does the audience value start with one of our whitelisted prefixes?
         for (const i in this.audiencePrefixes) {
             const prefix = this.audiencePrefixes[i];
-            if (audience.startsWith(prefix.toString())) {
+            if (audience.startsWith(prefix)) {
                 valid = true;
                 break;
             }
@@ -74,7 +74,7 @@ class GoogleOAuthAuthorizer {
         if (!valid) {
             for (const i in this.emailSuffixes) {
                 const suffix = this.emailSuffixes[i];
-                if (email.endsWith(suffix.toString())) {
+                if (email.endsWith(suffix)) {
                     valid = true;
                     break;
                 }

--- a/function/config.js.ctmpl
+++ b/function/config.js.ctmpl
@@ -3,7 +3,7 @@
 // 1) JS is lenient about trailing commas in these arrays
 // 2) JS **needs** the trailing comma if the array contains a single item, e.g. emailSuffixes.
 //      Without the trailing comma, JS will collapse the array.
-const audiencePrefixes = [{{range $index, $element := $commonSecrets.Data.client_ids}}{{ $element }},{{end}}];
+const audiencePrefixes = [{{range $index, $element := $commonSecrets.Data.client_ids}}'{{ $element }}',{{end}}];
 const emailSuffixes = ['.gserviceaccount.com',];
 
 module.exports = {

--- a/function/test/authorization.unit.test.js
+++ b/function/test/authorization.unit.test.js
@@ -228,8 +228,8 @@ test('authorization: should not replace "bearer " in the middle of the Authoriza
 class ArbitraryUserInfoMockAuthorizer extends GoogleOAuthAuthorizer {
     constructor(testUserInfo) {
         super({
-            audiencePrefixes: [123, 778899],
-            emailSuffixes: ['.unit.test', '.unittest.email.suffix.two'],
+            audiencePrefixes: ['123', '778899', '102392942264657484310'],
+            emailSuffixes: ['.unit.test', '.unittest.email.suffix.two', '.gserviceaccount.com'],
         });
         this.testUserInfo = testUserInfo;
     }
@@ -439,6 +439,26 @@ test('authorization: should validate if audience matches whitelist but email doe
         verified_email: true,
         expires_in: 500,
         audience: '778899000000-somestuff', // compare to ArbitraryUserInfoMockAuthorizer above
+        user_id: 456,
+    };
+
+    return tosapi(validReq, stubbedRes(), new ArbitraryUserInfoMockAuthorizer(userinfo), echoDatastore)
+        .then(datastoreResult => {
+            t.is(datastoreResult.userid, userinfo.user_id);
+            t.is(datastoreResult.email, userinfo.email);
+            t.true(datastoreResult.accepted);
+        });
+});
+
+// if we treat this test audience - 102392942264657484310 - as a number, JavaScript will
+// apply rounding because it doesn't have the right precision. This test verifies we
+// treat audiences as strings everywhere.
+test('authorization: should validate if audience is a large number', async t => {
+    const userinfo = {
+        email: 'email@unknown.suffix', // compare to ArbitraryUserInfoMockAuthorizer above
+        verified_email: true,
+        expires_in: 500,
+        audience: '102392942264657484310', // compare to ArbitraryUserInfoMockAuthorizer above
         user_id: 456,
     };
 


### PR DESCRIPTION
we had been treating oauth audience prefixes as numbers, but JavaScript doesn't natively have the right precision to handle them. Here's an example:
```
const foo = 102392942264657484310;
> undefined
foo
> 102392942264657480000
```

so as of this PR, we treat them as strings from the beginning.