### PR TITLE
status endpoint

### DIFF
--- a/function/datastore.js
+++ b/function/datastore.js
@@ -225,6 +225,24 @@ class GoogleDatastoreClient {
             });
     }
 
+    // ================================
+    // STATUS / HEALTH CHECKS
+    // ================================
+
+    healthCheckQuery(datastore) {
+        // currently, we query the app/Application kind and take the first entity that datastore returns.
+        // we don't care about the entity itself; we just want to know we can reach datastore and that
+        // it is capable of returning an entity.
+        //
+        // in the future, we may want to query for a specific known-good entity, but this is good
+        // enough for now.
+        const query = datastore
+            .createQuery(appNamespace, kindApplication)
+            .limit(1);
+
+        return datastore.runQuery(query);
+    };
+
 }
 
 module.exports = GoogleDatastoreClient;

--- a/function/datastore.js
+++ b/function/datastore.js
@@ -229,7 +229,7 @@ class GoogleDatastoreClient {
     // STATUS / HEALTH CHECKS
     // ================================
 
-    healthCheckQuery(datastore) {
+    healthCheckQuery() {
         // currently, we query the app/Application kind and take the first entity that datastore returns.
         // we don't care about the entity itself; we just want to know we can reach datastore and that
         // it is capable of returning an entity.

--- a/function/index.js
+++ b/function/index.js
@@ -32,6 +32,9 @@ const routes = {
     '/status': statushandler.handleRequest,
 };
 
+const liveAuthorizer = new GoogleOAuthAuthorizer();
+const liveDatastore = new GoogleDatastoreClient();
+
 /**
  * Implementation of the TOS APIs. This tosapi() function should always either:
  *  - throw an error
@@ -55,8 +58,8 @@ const tosapi = function(req, res, authClient, datastoreClient) {
     if (requestHandler) {
         // unit tests may override these. At runtime, when called as a live Cloud Function from tos(),
         // authClient and datastoreClient will be null.
-        const authorizer = authClient || new GoogleOAuthAuthorizer();
-        const datastore = datastoreClient || new GoogleDatastoreClient();
+        const authorizer = authClient || liveAuthorizer;
+        const datastore = datastoreClient || liveDatastore;
 
         return requestHandler(req, authorizer, datastore);
     } else {

--- a/function/index.js
+++ b/function/index.js
@@ -3,6 +3,8 @@
 const GoogleOAuthAuthorizer = require('./authorization');
 const GoogleDatastoreClient = require('./datastore');
 const toshandler = require('./toshandler.js');
+const statushandler = require('./statushandler.js');
+const {throwResponseError} = require('./validation.js');
 
 // handle CORS requests via 'cors' library
 const corsOptions = {
@@ -11,7 +13,7 @@ const corsOptions = {
 };
 const cors = require('cors')(corsOptions);
 
-function respondWithError(res, error, prefix) {
+const respondWithError = function(res, error, prefix) {
     const code = error.statusCode || 500;
     const pre = prefix || '';
     const respBody = pre + (error.message || JSON.stringify(error));
@@ -21,7 +23,14 @@ function respondWithError(res, error, prefix) {
         console.error(new Error('Error ' + code + ': ' + respBody));
     }
     res.status(code).json(respBody);
-}
+};
+
+const routes = {
+    '/v1/user/response': toshandler.handleRequest,
+    '/user/response': toshandler.handleRequest,
+    '/v1/status': statushandler.handleRequest,
+    '/status': statushandler.handleRequest,
+};
 
 /**
  * Implementation of the TOS APIs. This tosapi() function should always either:
@@ -39,15 +48,25 @@ function respondWithError(res, error, prefix) {
  * @param {*} datastoreClient The datastore client class used to read/write persistent data.
  *  This exists as an argument so tests can override it.
  */
-function tosapi(req, res, authClient, datastoreClient) {
-    // unit tests may override these. At runtime, when called as a live Cloud Function from tos(),
-    // authClient and datastoreClient will be null.
-    const authorizer = authClient || new GoogleOAuthAuthorizer();
-    const datastore = datastoreClient || new GoogleDatastoreClient();
+const tosapi = function(req, res, authClient, datastoreClient) {
 
-    // TODO: route to different handlers for userRequest vs. status
-    return toshandler.handleRequest(req, authorizer, datastore);
-}
+    const requestHandler = routes[req.path];
+
+    if (requestHandler) {
+        // unit tests may override these. At runtime, when called as a live Cloud Function from tos(),
+        // authClient and datastoreClient will be null.
+        const authorizer = authClient || new GoogleOAuthAuthorizer();
+        const datastore = datastoreClient || new GoogleDatastoreClient();
+
+        return requestHandler(req, authorizer, datastore);
+    } else {
+        throwResponseError(404);
+    }
+};
+
+const responseCode = function(payload) {
+    return (payload instanceof statushandler.StatusCheckResponse && !payload.ok) ? 500 : 200;
+};
 
 /**
  * Main entry point for the Cloud Function.
@@ -57,12 +76,12 @@ function tosapi(req, res, authClient, datastoreClient) {
  * and make its implementation - tosapi() - the testable one.
  *
  */
-function tos(req, res) {
+const tos = function(req, res) {
     try {
         cors(req, res, () => {
             tosapi(req, res, null, null)
                 .then(tosresult => {
-                    res.status(200).json(tosresult);
+                    res.status(responseCode(tosresult)).json(tosresult);
                 })
                 .catch(err => {
                     respondWithError(res, err);
@@ -71,7 +90,6 @@ function tos(req, res) {
     } catch (err) {
         respondWithError(res, err);
     }
-}
+};
 
-exports.tosapi = tosapi;
-exports.tos = tos;
+module.exports = {tosapi, tos, responseCode};

--- a/function/statushandler.js
+++ b/function/statushandler.js
@@ -25,7 +25,9 @@ class StatusCheckResponse {
 }
 
 // an in-memory "cache" to retain status responses.
-// we may eventually move to something like the memory-cache library.
+// we may eventually move to something more elegant.
+// this "cache" is only valid per cloud function instance, and Google will spin
+// up many instances to meet demand.
 let cache = null;
 
 const cacheGet = function() {
@@ -78,6 +80,7 @@ const handleRequest = function(req, authorizer, datastore) {
                 if (cachedLookup) {
                     console.info('returning cached status check.');
                     status = cachedLookup;
+                    return status;
                 } else {
                     console.info('calculating status.');
                     // rewrite this if we ever have more than one subsystem to check

--- a/function/statushandler.js
+++ b/function/statushandler.js
@@ -1,0 +1,108 @@
+'use strict';
+
+class SubsystemStatus {
+    /**
+     *
+     * @param {*} ok Boolean: is the subsystem healthy or not?
+     * @param {*} messages an array of error messages from this subsystem.
+     */
+    constructor(ok, messages) {
+        this.ok = !!ok;
+        this.messages = messages;
+    }
+}
+
+class StatusCheckResponse {
+    /**
+     *
+     * @param {*} ok Boolean: is the TOS API healthy or not?
+     * @param {*} systems Object; keys are subsytem name (String) and values are SubsystemStatus objects
+     */
+    constructor(ok, systems) {
+        this.ok = !!ok;
+        this.systems = systems;
+    }
+}
+
+// an in-memory "cache" to retain status responses.
+// we may eventually move to something like the memory-cache library.
+let cache = null;
+
+const cacheGet = function() {
+    const curTime = Date.now();
+    const cachedData = cache || {};
+    const cacheTime = cachedData.timestamp || 0;
+    if (curTime - cacheTime < 60000) { // 60000 millis == 1 minute
+        return cachedData.status;
+    } else {
+        return null;
+    }
+};
+
+const cachePut = function(status) {
+    cache = {
+        timestamp: Date.now(),
+        status: status,
+    };
+    return cacheGet();
+};
+
+const checkDatastoreStatus = function(datastore) {
+    return datastore.healthCheckQuery()
+        .then(results => {
+            // results object is an array that contains:
+            // [0]: array of rows returned
+            // [1]: metadata about the results
+            const hits = results[0];
+            if (hits.length === 1) {
+                return new SubsystemStatus(true);
+            } else {
+                return new SubsystemStatus(false, [hits.length + ' entities returned from Datastore.']);
+            }
+        })
+        .catch(err => {
+            return new SubsystemStatus(false, [err.message]);
+        });
+};
+
+const handleRequest = function(req, authorizer, datastore) {
+
+    // should we validate GET? without validation we allow any method, which could be fine
+
+    let status = new StatusCheckResponse(false, {});
+
+    return Promise.resolve()
+        .then(() => {
+            try {
+                const cachedLookup = cacheGet();
+                if (cachedLookup) {
+                    console.info('returning cached status check.');
+                    status = cachedLookup;
+                } else {
+                    console.info('calculating status.');
+                    // rewrite this if we ever have more than one subsystem to check
+                    return checkDatastoreStatus(datastore)
+                        .then(datastoreStatus => {
+                            status.systems.datastore = datastoreStatus;
+                            status.ok = datastoreStatus.ok;
+                            cachePut(status);
+                            return status;
+                        })
+                        .catch(err => {
+                            status.ok = false;
+                            status.systems.datastore = new SubsystemStatus(false, [err.message]);
+                            return status;
+                        });
+                }
+            } catch (err) {
+                status.ok = false;
+                status.systems.datastore = new SubsystemStatus(false, [err.message]);
+                return status;
+            }
+        })
+        .catch(err => {
+            return new SubsystemStatus(false, [err.message]);
+        });
+};
+
+module.exports = { handleRequest, StatusCheckResponse, SubsystemStatus };

--- a/function/test/status.unit.test.js
+++ b/function/test/status.unit.test.js
@@ -19,35 +19,35 @@ class ErroringMockAuthorizer extends GoogleOAuthAuthorizer {
 
 // mock datastore client that returns healthy
 class HealthyDatastoreClient extends GoogleDatastoreClient {
-    healthCheckQuery(datastore) {
+    healthCheckQuery() {
         return Promise.resolve([ [{}], {metadata: 'HealthyDatastoreClient'} ]);
     };
 }
 
 // mock datastore client that rejects
 class RejectingDatastoreClient extends GoogleDatastoreClient {
-    healthCheckQuery(datastore) {
+    healthCheckQuery() {
         return Promise.reject(new Error('RejectingDatastoreClient says reject!'));
     };
 }
 
 // mock datastore client that errors
 class ErroringDatastoreClient extends GoogleDatastoreClient {
-    healthCheckQuery(datastore) {
+    healthCheckQuery() {
         throw new Error('ErroringDatastoreClient says error!');
     };
 }
 
 // mock datastore client that succeeds but returns zero entities
 class EmptyDatastoreClient extends GoogleDatastoreClient {
-    healthCheckQuery(datastore) {
+    healthCheckQuery() {
         return Promise.resolve([ [], {metadata: 'EmptyDatastoreClient'} ]);
     };
 }
 
 // mock datastore client that succeeds but returns more than one entity
 class TwoEntityDatastoreClient extends GoogleDatastoreClient {
-    healthCheckQuery(datastore) {
+    healthCheckQuery() {
         return Promise.resolve([ [{}, {}], {metadata: 'TwoEntityDatastoreClient'} ]);
     };
 }

--- a/function/test/status.unit.test.js
+++ b/function/test/status.unit.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+const test = require('ava');
+const sinon = require('sinon');
+const GoogleOAuthAuthorizer = require('../authorization');
+const GoogleDatastoreClient = require('../datastore');
+const { tosapi, responseCode } = require('../index');
+const { StatusCheckResponse, SubsystemStatus } = require('../statushandler');
+
+process.env.NODE_ENV = 'test';
+
+// mock authorizer that always rejects. The status API should not attempt authorization;
+// if we see this error then the status code path is faulty.
+class ErroringMockAuthorizer extends GoogleOAuthAuthorizer {
+    callTokenInfoApi(userinfoStr) {
+        return Promise.reject(new Error('ErroringMockAuthorizer should never be called!'));
+    }
+}
+
+// mock datastore client that returns healthy
+class HealthyDatastoreClient extends GoogleDatastoreClient {
+    healthCheckQuery(datastore) {
+        return Promise.resolve([ [{}], {metadata: 'HealthyDatastoreClient'} ]);
+    };
+}
+
+// mock datastore client that rejects
+class RejectingDatastoreClient extends GoogleDatastoreClient {
+    healthCheckQuery(datastore) {
+        return Promise.reject(new Error('RejectingDatastoreClient says reject!'));
+    };
+}
+
+// mock datastore client that errors
+class ErroringDatastoreClient extends GoogleDatastoreClient {
+    healthCheckQuery(datastore) {
+        throw new Error('ErroringDatastoreClient says error!');
+    };
+}
+
+// mock datastore client that succeeds but returns zero entities
+class EmptyDatastoreClient extends GoogleDatastoreClient {
+    healthCheckQuery(datastore) {
+        return Promise.resolve([ [], {metadata: 'EmptyDatastoreClient'} ]);
+    };
+}
+
+// mock datastore client that succeeds but returns more than one entity
+class TwoEntityDatastoreClient extends GoogleDatastoreClient {
+    healthCheckQuery(datastore) {
+        return Promise.resolve([ [{}, {}], {metadata: 'TwoEntityDatastoreClient'} ]);
+    };
+}
+
+// helpers to create request/response objects
+const stubbedRes = function() {
+    return {
+        setHeader: sinon.stub(),
+        send: sinon.stub(),
+        json: sinon.stub(),
+        status: sinon.stub().returnsThis(),
+    };
+};
+
+const getRequest = function(versioned = false) {
+    return {
+        path: versioned ? '/v1/status' : '/status',
+        method: 'GET',
+        headers: {
+            origin: 'unittest',
+        },
+    };
+};
+
+test('status: should return StatusCheckResponse if all went well', async t => {
+    const req = getRequest();
+    const res = stubbedRes();
+
+    return tosapi(req, res, new ErroringMockAuthorizer(), new HealthyDatastoreClient())
+        .then(statusResult => {
+            t.true(statusResult.ok);
+            t.is(Object.keys(statusResult.systems).length, 1);
+            t.truthy(statusResult.systems.datastore);
+            t.true(statusResult.systems.datastore.ok);
+            t.is(statusResult.systems.datastore.messages, undefined);
+        });
+});
+
+test('status: should return downed StatusCheckResponse if datastore rejected', async t => {
+    const req = getRequest();
+    const res = stubbedRes();
+
+    return tosapi(req, res, new ErroringMockAuthorizer(), new RejectingDatastoreClient())
+        .then(statusResult => {
+            t.false(statusResult.ok);
+            t.is(Object.keys(statusResult.systems).length, 1);
+            t.truthy(statusResult.systems.datastore);
+            t.false(statusResult.systems.datastore.ok);
+            t.is(statusResult.systems.datastore.messages.length, 1);
+            t.is(statusResult.systems.datastore.messages.pop(), 'RejectingDatastoreClient says reject!');
+        });
+});
+
+test('status: should return downed StatusCheckResponse if datastore throws error', async t => {
+    const req = getRequest();
+    const res = stubbedRes();
+
+    return tosapi(req, res, new ErroringMockAuthorizer(), new ErroringDatastoreClient())
+        .then(statusResult => {
+            t.false(statusResult.ok);
+            t.is(Object.keys(statusResult.systems).length, 1);
+            t.truthy(statusResult.systems.datastore);
+            t.false(statusResult.systems.datastore.ok);
+            t.is(statusResult.systems.datastore.messages.length, 1);
+            t.is(statusResult.systems.datastore.messages.pop(), 'ErroringDatastoreClient says error!');
+        });
+});
+
+test('status: should return downed StatusCheckResponse if datastore returns zero entities', async t => {
+    const req = getRequest();
+    const res = stubbedRes();
+
+    return tosapi(req, res, new ErroringMockAuthorizer(), new EmptyDatastoreClient())
+        .then(statusResult => {
+            t.false(statusResult.ok);
+            t.is(Object.keys(statusResult.systems).length, 1);
+            t.truthy(statusResult.systems.datastore);
+            t.false(statusResult.systems.datastore.ok);
+            t.is(statusResult.systems.datastore.messages.length, 1);
+            t.is(statusResult.systems.datastore.messages.pop(), '0 entities returned from Datastore.');
+        });
+});
+
+test('status: should return downed StatusCheckResponse if datastore returns >1 entities', async t => {
+    const req = getRequest();
+    const res = stubbedRes();
+
+    return tosapi(req, res, new ErroringMockAuthorizer(), new TwoEntityDatastoreClient())
+        .then(statusResult => {
+            t.false(statusResult.ok);
+            t.is(Object.keys(statusResult.systems).length, 1);
+            t.truthy(statusResult.systems.datastore);
+            t.false(statusResult.systems.datastore.ok);
+            t.is(statusResult.systems.datastore.messages.length, 1);
+            t.is(statusResult.systems.datastore.messages.pop(), '2 entities returned from Datastore.');
+        });
+});
+
+// the versioned status endpoint uses the same codepath as the non-versioned one, so we only smoke
+// test it here.
+test('status: should return StatusCheckResponse if all went well on the versioned endpoint', async t => {
+    const req = getRequest(true);
+    const res = stubbedRes();
+
+    return tosapi(req, res, new ErroringMockAuthorizer(), new HealthyDatastoreClient())
+        .then(statusResult => {
+            t.true(statusResult.ok);
+            t.is(Object.keys(statusResult.systems).length, 1);
+            t.truthy(statusResult.systems.datastore);
+            t.true(statusResult.systems.datastore.ok);
+            t.is(statusResult.systems.datastore.messages, undefined);
+        });
+});
+
+
+test('status: should return downed StatusCheckResponse if datastore rejected' +
+        ' on the versioned endpoint', async t => {
+    const req = getRequest(true);
+    const res = stubbedRes();
+
+    return tosapi(req, res, new ErroringMockAuthorizer(), new RejectingDatastoreClient())
+        .then(statusResult => {
+            t.false(statusResult.ok);
+            t.is(Object.keys(statusResult.systems).length, 1);
+            t.truthy(statusResult.systems.datastore);
+            t.false(statusResult.systems.datastore.ok);
+            t.is(statusResult.systems.datastore.messages.length, 1);
+            t.is(statusResult.systems.datastore.messages.pop(), 'RejectingDatastoreClient says reject!');
+        });
+});
+
+
+test('responseCode function: should use http 200 for up StatusCheckResponse', t => {
+    const status = new StatusCheckResponse(true, {});
+    t.is(responseCode(status), 200);
+});
+
+test('responseCode function: should use http 200 for up StatusCheckResponse even with subsystem fails', t => {
+    const subsys = new SubsystemStatus(false, ['failed subsystem']);
+    const status = new StatusCheckResponse(true, {
+        datastore: subsys,
+    });
+    t.is(responseCode(status), 200);
+});
+
+test('responseCode function: should use http 500 for down StatusCheckResponse', t => {
+    const status = new StatusCheckResponse(false, {});
+    t.is(responseCode(status), 500);
+});
+
+test('responseCode function: should use http 500 for down StatusCheckResponse with subsystem success', t => {
+    const subsys = new SubsystemStatus(true, []);
+    const status = new StatusCheckResponse(false, {
+        datastore: subsys,
+    });
+    t.is(responseCode(status), 500);
+});
+
+test('responseCode function: should use http 200 for non-StatusCheckResponse payload', t => {
+    const payload = [[{}], {metadata: 'foo'}];
+    t.is(responseCode(payload), 200);
+});
+
+test('responseCode function: should use http 200 for non-StatusCheckResponse payload with ok field', t => {
+    const payload = {ok: false};
+    t.is(responseCode(payload), 200);
+});

--- a/function/toshandler.js
+++ b/function/toshandler.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const {validateRequestUrl, validateRequestMethod, validateContentType,
+const {validateRequestMethod, validateContentType,
     requireAuthorizationHeader, validateInputs} = require('./validation.js');
 const { prefixedRejection } = require('./responseError');
 
 const handleRequest = function(req, authorizer, datastore) {
-    validateRequestUrl(req);
     validateRequestMethod(req);
     validateContentType(req);
     const authHeader = requireAuthorizationHeader(req);

--- a/function/validation.js
+++ b/function/validation.js
@@ -6,12 +6,6 @@ const throwResponseError = function(statusCode, message) {
     throw new ResponseError(message, statusCode);
 };
 
-const validateRequestUrl = function(req) {
-    if (req.path !== '/v1/user/response' && req.path !== '/user/response') {
-        throwResponseError(404);
-    }
-};
-
 const validateRequestMethod = function(req) {
     if (!['GET', 'POST', 'OPTIONS'].includes(req.method)) {
         throwResponseError(405);
@@ -87,5 +81,5 @@ const validateInputs = function(req) {
     }
 };
 
-module.exports = {throwResponseError, validateRequestUrl, validateRequestMethod, requireAuthorizationHeader,
+module.exports = {throwResponseError, validateRequestMethod, requireAuthorizationHeader,
     validateContentType, validateInputs};


### PR DESCRIPTION
DataBiosphere/firecloud-app#199: add a /status endpoint.

Returns the same payload structure as orchestration, rawls, sam, etc.

This status endpoint has one subsystem - Datastore. We make a query to datastore to ensure permissions and other connectivity is set up correctly.

I've also implemented a "cache" to ensure we don't hammer Datastore in the event we query the /status endpoint frequently. I'd love your opinion on the cache - does it even make sense, given the elastic nature of Cloud Function instances?

Finally, note that the /status endpoint will hopefully have a (good) side effect - if we query it regularly from pingdom or some other monitoring service, it will ensure that we keep a Cloud Function instance alive and avoid the [cold start problem](https://cloud.google.com/functions/docs/bestpractices/tips).