### PR TITLE
upgrade to nodejs8 runtime [risk: low]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ version: 2
 jobs:
   build:
     docker:
-      # This Cloud Function uses the Node.js 6 runtime
-      - image: circleci/node:6.14
+      # This Cloud Function uses the Node.js 8 runtime
+      - image: circleci/node:8.15
 
     # all the Node.js code is in the subdirectory "function". Set this as the default working directory
     # but make sure to override the working dir for steps like checkout.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ APIs - currently implemented as a Cloud Function - for users' responses to Terms
 
 # Developer setup
 ## Prerequisites
-This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 6.14, or whatever minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/nodejs-6-runtime.
+This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 8.15, or whatever minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/nodejs-8-runtime.
 
 If you already have a different version of Node on your system, you might be interested in *[nvm](https://github.com/creationix/nvm)*.
 
-If you have a hard time finding Node 6.14 to install, you really might be interested in *[nvm](https://github.com/creationix/nvm)*. First, install *nvm* according to their instructions. Then, use *nvm* to install and use the appropriate version of Node, e.g. `nvm install 6.14.4`. *nvm* will automatically use the version of Node you just installed, but for good measure you can `nvm ls` to see installed versions, then `nvm use 6.14.4` to use that version if you aren't already using it.
+If you have a hard time finding Node 8.15 to install, you really might be interested in *[nvm](https://github.com/creationix/nvm)*. First, install *nvm* according to their instructions. Then, use *nvm* to install and use the appropriate version of Node, e.g. `nvm install 8.15.0`. *nvm* will automatically use the version of Node you just installed, but for good measure you can `nvm ls` to see installed versions, then `nvm use 8.15.0` to use that version if you aren't already using it.
 
 To install third-party libraries, first `cd function`, then `npm install`. You will need to `npm install` any time [package.json](function/package.json) or [package-lock.json](function/package-lock.json) changes. Conversely, if those files have not changed since your last install, you should not have to run `npm install`.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,4 +57,4 @@ docker run --rm -v $PWD:${CODEBASE_PATH} \
     "gcloud config set project ${PROJECT_NAME} &&
      gcloud auth activate-service-account --key-file ${CODEBASE_PATH}/${SERVICE_ACCT_KEY_FILE} &&
      cd ${CODEBASE_PATH} &&
-     gcloud functions deploy tos --source=./function --trigger-http --runtime nodejs6"
+     gcloud functions deploy tos --source=./function --trigger-http --runtime nodejs8"


### PR DESCRIPTION
The nodejs6 runtime for Google Cloud Functions is now deprecated, and will be decommissioned in a year (April 22, 2020): https://cloud.google.com/functions/docs/migrating/nodejs-runtimes

This PR upgrades workbench-tos to the nodejs8 runtime:
* readmes updated
* deploy-to-cloud-function script updated to specify nodejs8
* CircleCI tests updated to specify nodejs8

for context, when we originally wrote the workbench-tos service, the nodejs8 runtime was in beta and nodejs6 was the stable/supported choice.

This nodejs8 version is already deployed and running in the Workbench dev env, without problems.