### PR TITLE
set SourceClear scanning scope to production

### DIFF
--- a/function/.gcloudignore
+++ b/function/.gcloudignore
@@ -18,4 +18,5 @@
 .nyc_output
 config.js.ctmpl
 node_modules
+srcclr.yml
 test

--- a/function/srcclr.yml
+++ b/function/srcclr.yml
@@ -1,0 +1,2 @@
+# Prevent scanning 'devDependencies' for an NPM project
+scope: production


### PR DESCRIPTION
add a `srcclr.yml` that tells SourceClear to ignore `devDependencies` and scan only the production/runtime libraries.

look for "Multi-Language Directives Scope" here:
https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/pG2XJlS_Y5jGwevF4c1E4w

