### PR TITLE
AS-361: upgrade to nodejs10 runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ version: 2
 jobs:
   build:
     docker:
-      # This Cloud Function uses the Node.js 8 runtime
-      - image: circleci/node:8.15
+      # This Cloud Function uses the Node.js 10 runtime
+      - image: circleci/node:10.18.1
 
     # all the Node.js code is in the subdirectory "function". Set this as the default working directory
     # but make sure to override the working dir for steps like checkout.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ APIs - currently implemented as a Cloud Function - for users' responses to Terms
 
 # Developer setup
 ## Prerequisites
-This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 8.15, or whatever minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/nodejs-8-runtime.
+This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 10.18.1, or whatever minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/nodejs-10-runtime.
 
 If you already have a different version of Node on your system, you might be interested in *[nvm](https://github.com/creationix/nvm)*.
 
-If you have a hard time finding Node 8.15 to install, you really might be interested in *[nvm](https://github.com/creationix/nvm)*. First, install *nvm* according to their instructions. Then, use *nvm* to install and use the appropriate version of Node, e.g. `nvm install 8.15.0`. *nvm* will automatically use the version of Node you just installed, but for good measure you can `nvm ls` to see installed versions, then `nvm use 8.15.0` to use that version if you aren't already using it.
+If you have a hard time finding Node 10.18.1 to install, you really might be interested in *[nvm](https://github.com/creationix/nvm)*. First, install *nvm* according to their instructions. Then, use *nvm* to install and use the appropriate version of Node, e.g. `nvm install v10.18.1`. *nvm* will automatically use the version of Node you just installed, but for good measure you can `nvm ls` to see installed versions, then `nvm use v10.18.1` to use that version if you aren't already using it.
 
 To install third-party libraries, first `cd function`, then `npm install`. You will need to `npm install` any time [package.json](function/package.json) or [package-lock.json](function/package-lock.json) changes. Conversely, if those files have not changed since your last install, you should not have to run `npm install`.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -55,7 +55,7 @@ docker run --rm -v $PWD:${CODEBASE_PATH} \
 # but it is not set automatically for nodejs 10; therefore we set it here during deploy.
 docker run --rm -v $PWD:${CODEBASE_PATH} \
     -e BASE_URL="https://us-central1-broad-dsde-${ENVIRONMENT}.cloudfunctions.net" \
-    google/cloud-sdk:308.0.0 /bin/bash -c \
+    google/cloud-sdk:307.0.0 /bin/bash -c \
     "gcloud config set project ${PROJECT_NAME} &&
      gcloud auth activate-service-account --key-file ${CODEBASE_PATH}/${SERVICE_ACCT_KEY_FILE} &&
      cd ${CODEBASE_PATH} &&

--- a/deploy.sh
+++ b/deploy.sh
@@ -55,7 +55,7 @@ docker run --rm -v $PWD:${CODEBASE_PATH} \
 # but it is not set automatically for nodejs 10; therefore we set it here during deploy.
 docker run --rm -v $PWD:${CODEBASE_PATH} \
     -e BASE_URL="https://us-central1-broad-dsde-${ENVIRONMENT}.cloudfunctions.net" \
-    google/cloud-sdk:220.0.0 /bin/bash -c \
+    google/cloud-sdk:308.0.0 /bin/bash -c \
     "gcloud config set project ${PROJECT_NAME} &&
      gcloud auth activate-service-account --key-file ${CODEBASE_PATH}/${SERVICE_ACCT_KEY_FILE} &&
      cd ${CODEBASE_PATH} &&

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,4 +57,4 @@ docker run --rm -v $PWD:${CODEBASE_PATH} \
     "gcloud config set project ${PROJECT_NAME} &&
      gcloud auth activate-service-account --key-file ${CODEBASE_PATH}/${SERVICE_ACCT_KEY_FILE} &&
      cd ${CODEBASE_PATH} &&
-     gcloud functions deploy tos --source=./function --trigger-http --runtime nodejs8"
+     gcloud functions deploy tos --source=./function --trigger-http --runtime nodejs10"

--- a/deploy.sh
+++ b/deploy.sh
@@ -51,10 +51,12 @@ docker run --rm -v $PWD:${CODEBASE_PATH} \
 
 # Use google/cloud-sdk image to deploy the cloud function
 # TODO: is there a smaller version of this image we can use?
+# GCP_PROJECT env var was set automatically for nodejs 6 and 8, and the runtime code uses it.
+# but it is not set automatically for nodejs 10; therefore we set it here during deploy.
 docker run --rm -v $PWD:${CODEBASE_PATH} \
     -e BASE_URL="https://us-central1-broad-dsde-${ENVIRONMENT}.cloudfunctions.net" \
     google/cloud-sdk:220.0.0 /bin/bash -c \
     "gcloud config set project ${PROJECT_NAME} &&
      gcloud auth activate-service-account --key-file ${CODEBASE_PATH}/${SERVICE_ACCT_KEY_FILE} &&
      cd ${CODEBASE_PATH} &&
-     gcloud functions deploy tos --source=./function --trigger-http --runtime nodejs10"
+     gcloud functions deploy tos --source=./function --trigger-http --runtime nodejs10 --set-env-vars GCP_PROJECT=${PROJECT_NAME}"


### PR DESCRIPTION
upgrade to nodejs10, due to Google's deprecation of the nodejs8 runtime.

this branch is currently running in the dev env as a proof that it works! when this merges, it'll get redeployed from the `develop` branch but will act the same.