### PR TITLE
upgrade to nodejs14 [AS-814]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
 
     strategy:
       matrix:
-        # this service deploys to Cloud Functions using nodejs 10 runtime. We test 12
+        # this service deploys to Cloud Functions using nodejs 14 runtime. We test 16
         # proactively for the future day when we'll upgrade.
-        node-version: [10.x, 12.x]
+        node-version: [14.x, 16.x]
 
     steps:
     
@@ -40,14 +40,14 @@ jobs:
       working-directory: function
     
     - name: Calculate coverage
-      # only for node 10
-      if: ${{ matrix.node-version == '10.x' }}
+      # only for node 14
+      if: ${{ matrix.node-version == '14.x' }}
       run: ./node_modules/.bin/nyc report --reporter=lcov --report-dir=test/reports/coverage
       working-directory: function
     
     - name: Upload to codecov
-      # only for node 10
-      if: ${{ matrix.node-version == '10.x' }}
+      # only for node 14
+      if: ${{ matrix.node-version == '14.x' }}
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ APIs - currently implemented as a Cloud Function - for users' responses to Terms
 
 # Developer setup
 ## Prerequisites
-This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 10.18.1, or whatever minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/nodejs-10-runtime.
+This codebase requires *[npm](https://docs.npmjs.com/getting-started/what-is-npm)* and *[Node.js](https://nodejs.org/en/)*. Specifically, it wants Node.js version 14, or any specific minor/patch version Google documents at https://cloud.google.com/functions/docs/concepts/exec#runtimes.
 
 If you already have a different version of Node on your system, you might be interested in *[nvm](https://github.com/creationix/nvm)*.
 
-If you have a hard time finding Node 10.18.1 to install, you really might be interested in *[nvm](https://github.com/creationix/nvm)*. First, install *nvm* according to their instructions. Then, use *nvm* to install and use the appropriate version of Node, e.g. `nvm install v10.18.1`. *nvm* will automatically use the version of Node you just installed, but for good measure you can `nvm ls` to see installed versions, then `nvm use v10.18.1` to use that version if you aren't already using it.
+If you have a hard time finding Node 14 to install, you really might be interested in *[nvm](https://github.com/creationix/nvm)*. First, install *nvm* according to their instructions. Then, use *nvm* to install and use the appropriate version of Node, e.g. `nvm install v14`. *nvm* will automatically use the version of Node you just installed, but for good measure you can `nvm ls` to see installed versions, then `nvm use v14` to use that version if you aren't already using it.
 
 To install third-party libraries, first `cd function`, then `npm install`. You will need to `npm install` any time [package.json](function/package.json) or [package-lock.json](function/package-lock.json) changes. Conversely, if those files have not changed since your last install, you should not have to run `npm install`.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -54,11 +54,11 @@ docker run --rm -v $PWD:${CODEBASE_PATH} \
 # Use google/cloud-sdk image to deploy the cloud function
 # TODO: is there a smaller version of this image we can use?
 # GCP_PROJECT env var was set automatically for nodejs 6 and 8, and the runtime code uses it.
-# but it is not set automatically for nodejs 10; therefore we set it here during deploy.
+# but it is not set automatically for nodejs 14; therefore we set it here during deploy.
 docker run --rm -v $PWD:${CODEBASE_PATH} \
     -e BASE_URL="https://us-central1-broad-dsde-${ENVIRONMENT}.cloudfunctions.net" \
     google/cloud-sdk:307.0.0 /bin/bash -c \
     "gcloud config set project ${PROJECT_NAME} &&
      gcloud auth activate-service-account --key-file ${CODEBASE_PATH}/${SERVICE_ACCT_KEY_FILE} &&
      cd ${CODEBASE_PATH} &&
-     gcloud functions deploy tos --source=./function --trigger-http --runtime nodejs10 --set-env-vars GCP_PROJECT=${PROJECT_NAME}"
+     gcloud functions deploy tos --source=./function --trigger-http --runtime nodejs14 --set-env-vars GCP_PROJECT=${PROJECT_NAME}"


### PR DESCRIPTION
upgrade to nodejs14 runtime, proactively before Google retires nodejs10 for cloud functions.

**_Reviewer:_** important! This repo is currently set up to require passing checks on the `test (10.x)` and `test (12.x)` jobs. In this PR, these show up as yellow with "Waiting for status to be reported", because we're now testing on 14.x and 16.x. If/when this PR is approved, I'll update the required checks and then merge.